### PR TITLE
2020-membership: add @samford

### DIFF
--- a/2020-membership.md
+++ b/2020-membership.md
@@ -32,6 +32,7 @@
 @Rylan12
 @ran-dall
 @reitermarkus
+@samford
 @scpeters
 @Sharpie
 @sjackman


### PR DESCRIPTION
I happened to be looking through the governance repositories today and noticed that I'm missing from the `2020-membership.md` document. I'm not looking to toot my own horn but I imagine we do want this information to be accurate, so this PR adds me to the list.

For context, I was invited to become a maintainer on 2020-02-18, I accepted, and it became official in the next day or two. Some maintainers who were invited after me are present in the 2020 membership list, so this seems like a simple oversight.

If PRs to this repository should only be opened by leadership, let me know and I'll close this.